### PR TITLE
In MySQL 5.7.x the thread_concurrency variable is removed.

### DIFF
--- a/templates/mysql.properties.erb
+++ b/templates/mysql.properties.erb
@@ -1,6 +1,3 @@
-# Set to (CPUs or Cores * 2) for max performance
-thread_concurrency=2
-
 # Memory is only allocated when needed and immediately released
 max_allowed_packet=1024M
 default_storage_engine=InnoDB


### PR DESCRIPTION
Tested with Team Server 3.5.9